### PR TITLE
[Fix] Fix logging overuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ Path can be anything you decide. However, some characters such as ```/``` might 
 
 ### Local Installation
 
+Before we get started, we need to set up the logging directory.
+
+```bash
+# Make sure that the directory /var/log/globalmon/ exists or create it.
+sudo mkdir -p /var/log/globalmon
+# Ensure the user running the Python script has write permissions to the directory
+sudo chmod -R 755 /var/log/globalmon
+sudo chown -R $USER:$USER /var/log/globalmon
+# Replace $USER with the username running the script IF necessary.
+```
+
 To build and install the globalmon package use the following command:
 
 ```

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -17,4 +17,4 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Run my_app.py with the specified config file
-globalmon --config "$CONFIG_FILE"  >> /var/log/globalmon/globalmon.log 2>&1
+globalmon --config "$CONFIG_FILE"

--- a/src/globalmon/globalmon_worker.py
+++ b/src/globalmon/globalmon_worker.py
@@ -19,6 +19,7 @@ from globalmon.utils import (
     log_to_statsd,
 )
 
+logger = logging.getLogger("globalmon_logger")
 
 class GlobalmonWorker:
     def __init__(self, config) -> None:
@@ -34,7 +35,7 @@ class GlobalmonWorker:
         """
         while self.keep_running:
             try:
-                logging.info("Starting worker thread...")
+                logger.info("Starting worker thread...")
                 # print(f"Running with configuration file: \n{self.config}")
 
                 heartbeat_results = heartbeat_check(self.config['services'])
@@ -50,7 +51,7 @@ class GlobalmonWorker:
                 time.sleep(period)
 
             except Exception as e:
-                logging.exception(f"An error occurred: {e}")
+                logger.exception(f"An error occurred: {e}")
 
     def stop(self):
         """

--- a/src/globalmon/globalmon_worker.py
+++ b/src/globalmon/globalmon_worker.py
@@ -21,6 +21,7 @@ from globalmon.utils import (
 
 logger = logging.getLogger("globalmon_logger")
 
+
 class GlobalmonWorker:
     def __init__(self, config) -> None:
         self.config = config

--- a/src/globalmon/server.py
+++ b/src/globalmon/server.py
@@ -54,7 +54,7 @@ def main():
 
     period = args.period
 
-        # Define the log file location
+    # Define the log file location
     log_file = "/var/log/globalmon/globalmon.log"
 
     # Create a custom logger
@@ -64,12 +64,15 @@ def main():
         # Set the level of the logger to DEBUG
         logger.setLevel(logging.DEBUG)
     else:
-        # Set the level of the logger to WARNING (INFO messages will be excluded)
+        # Set the level of the logger to WARNING (INFO messages will be
+        # excluded)
         logger.setLevel(logging.WARNING)
 
     # Create a rotating file handler
     # Max file size: 5 MB, keep 3 backup files
-    handler = RotatingFileHandler(log_file, maxBytes=5 * 1024 * 1024, backupCount=3)
+    handler = RotatingFileHandler(
+        log_file, maxBytes=5 * 1024 * 1024,
+        backupCount=3)
 
     # Set the format for the logs
     formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
@@ -89,7 +92,7 @@ def main():
     config = load_config(config_filepath)
 
     # Your main application logic here
-    logger.info("Reading configuration:")
+    print("Reading configuration:")
     print(config)
 
     logger.info("Creating a new worker.")

--- a/src/globalmon/server.py
+++ b/src/globalmon/server.py
@@ -16,6 +16,7 @@ import argparse
 import yaml
 import threading
 import logging
+from logging.handlers import RotatingFileHandler
 from globalmon.globalmon_worker import GlobalmonWorker
 
 
@@ -53,18 +54,33 @@ def main():
 
     period = args.period
 
+        # Define the log file location
+    log_file = "/var/log/globalmon/globalmon.log"
+
+    # Create a custom logger
+    logger = logging.getLogger("globalmon_logger")
+
     if args.debug:
-        logging.basicConfig(
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            level=logging.DEBUG)
+        # Set the level of the logger to DEBUG
+        logger.setLevel(logging.DEBUG)
     else:
-        logging.basicConfig(
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            level=logging.INFO)
+        # Set the level of the logger to WARNING (INFO messages will be excluded)
+        logger.setLevel(logging.WARNING)
+
+    # Create a rotating file handler
+    # Max file size: 5 MB, keep 3 backup files
+    handler = RotatingFileHandler(log_file, maxBytes=5 * 1024 * 1024, backupCount=3)
+
+    # Set the format for the logs
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    handler.setFormatter(formatter)
+
+    # Add the handler to the logger
+    logger.addHandler(handler)
 
     config_filepath = args.config
 
-    logging.info("Loading configuration file.")
+    logger.info("Loading configuration file.")
     # Check if the file extension is .yaml or .yml
     if not config_filepath.lower().endswith(('.yaml', '.yml')):
         raise ValueError("Config file must be a YAML file (.yaml or .yml)")
@@ -73,10 +89,10 @@ def main():
     config = load_config(config_filepath)
 
     # Your main application logic here
-    print("Reading configuration:")
+    logger.info("Reading configuration:")
     print(config)
 
-    logging.info("Creating a new worker.")
+    logger.info("Creating a new worker.")
     globalmonWorker = GlobalmonWorker(config)
 
     # Create a new thread

--- a/src/globalmon/utils.py
+++ b/src/globalmon/utils.py
@@ -16,6 +16,7 @@ import requests
 import logging
 import statsd
 
+logger = logging.getLogger("globalmon_logger")
 
 def heartbeat_check(services):
     """
@@ -40,7 +41,7 @@ def heartbeat_check(services):
     """
     result = {}
     for service, url_list in services.items():
-        # logging.info(f"Checking {service}...")
+        # logger.info(f"Checking {service}...")
         result[service] = {}
         for url in url_list['urls']:
             try:
@@ -62,14 +63,14 @@ def heartbeat_check(services):
                 result[service][url] = return_data
             except requests.exceptions.ConnectionError as e:
                 # Log name resolution and other connection failures
-                logging.error(f"Connection error for {url}: {str(e)}")
+                logger.error(f"Connection error for {url}: {str(e)}")
                 return_data = {
                     'return_code': 'connection_failed',
                     'return_time': 0
                 }
                 result[service][url] = return_data
             except requests.RequestException as e:
-                logging.error(f"Request failed for {url}: {str(e)}")
+                logger.error(f"Request failed for {url}: {str(e)}")
                 return_data = {
                     'return_code': 'failed',
                     'return_time': 0
@@ -104,7 +105,7 @@ def log_to_statsd(statsd_client, path_prefix, results):
     """
 
     for service, service_results in results.items():
-        # logging.info(f"Logging {service}...")
+        # logger.info(f"Logging {service}...")
         for url, response in service_results.items():
             domain = url.split('/')[2].replace(".", "_")
             service_path = f'{path_prefix}.{service}.{domain}'

--- a/src/globalmon/utils.py
+++ b/src/globalmon/utils.py
@@ -18,6 +18,7 @@ import statsd
 
 logger = logging.getLogger("globalmon_logger")
 
+
 def heartbeat_check(services):
     """
     Checks the reachability of URLs defined in dictionary 'services'

--- a/tests/test_log_to_statsd.py
+++ b/tests/test_log_to_statsd.py
@@ -20,9 +20,9 @@ class TestLogToStatsd(unittest.TestCase):
         # Verify both increment calls
         mock_client.incr.assert_has_calls([
             # First increment call with the return code
-            unittest.mock.call('counter.prefix.example_service.example_com.200'), # noqa
+            unittest.mock.call('counter.prefix.example_service.example_com.200'),  # noqa
             # Second increment call for 'attempted'
-            unittest.mock.call('counter.prefix.example_service.example_com.attempted') # noqa
+            unittest.mock.call('counter.prefix.example_service.example_com.attempted')  # noqa
         ], any_order=True)
 
 


### PR DESCRIPTION
Currently logging is passed to log file using redirect operator in entrypoint.sh. this creates huge log file which includes info messages.
Furthermore, log file is always open and in case any deletion is made or the file is cleared, logging won't work anymore.

FIX: Create a log file that include warn or greater level messages to log file using a custom logger. max size is set to 5MB and 3 backups at most. debug mode can be enabled normally as it was earlier by using a debug flag with globalmon

MAKE SURE: /var/log/globalmon directory exists and is owned by the user and has permission to write there. It is taken care of in the Dockerfile already. 


