### PR TITLE
[Feat.] Use complete URL path as statsd path identifier

### DIFF
--- a/src/globalmon/utils.py
+++ b/src/globalmon/utils.py
@@ -121,10 +121,17 @@ def log_to_statsd(statsd_client, path_prefix, results):
 
 
 def convert_url_to_identifier(url):
+    # FUTURE REFERENCE
+    # Add a default scheme if missing
+    if not urlparse(url).scheme:
+        url = "http://" + url
     parsed_url = urlparse(url)
+    # Get the domain and path
     domain = parsed_url.netloc
-    # Remove leading/trailing slashes
     path = parsed_url.path.strip('/')
     # Combine domain and path, replacing '.' and '/' with '_'
-    combined = f"{domain}/{path}".replace(".", "_").replace("/", "_")
+    if path:
+        combined = f"{domain}/{path}".replace(".", "_").replace("/", "_")
+    else:
+        combined = domain.replace(".", "_")
     return combined

--- a/tests/test_convert_url_to_identifier.py
+++ b/tests/test_convert_url_to_identifier.py
@@ -1,0 +1,49 @@
+import unittest
+from globalmon.utils import convert_url_to_identifier
+
+
+# Test cases
+class TestConvertUrlToIdentifier(unittest.TestCase):
+    def test_simple_url(self):
+        url = "https://example.com/path"
+        result = convert_url_to_identifier(url)
+        self.assertEqual(result, "example_com_path")
+
+    def test_url_without_path(self):
+        url = "https://example.com"
+        result = convert_url_to_identifier(url)
+        self.assertEqual(result, "example_com")
+
+    def test_url_with_multiple_paths(self):
+        url = "https://example.com/path/to/resource"
+        result = convert_url_to_identifier(url)
+        self.assertEqual(result, "example_com_path_to_resource")
+
+    def test_url_with_trailing_slash(self):
+        url = "https://example.com/path/"
+        result = convert_url_to_identifier(url)
+        self.assertEqual(result, "example_com_path")
+
+    def test_url_with_subdomain(self):
+        url = "https://sub.example.com/path"
+        result = convert_url_to_identifier(url)
+        self.assertEqual(result, "sub_example_com_path")
+
+    def test_url_with_no_protocol(self):
+        url = "example.com/path"
+        result = convert_url_to_identifier(url)
+        self.assertEqual(result, "example_com_path")
+
+    def test_url_with_query_params(self):
+        url = "https://example.com/path?query=1"
+        result = convert_url_to_identifier(url)
+        self.assertEqual(result, "example_com_path")
+
+    def test_url_with_fragment(self):
+        url = "https://example.com/path#section"
+        result = convert_url_to_identifier(url)
+        self.assertEqual(result, "example_com_path")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Different URL paths with same domains need separate logging path identifier.

Refer #13 